### PR TITLE
Improved postal code validation

### DIFF
--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -472,7 +472,7 @@ class ValidationRules
     {
         ValidationMessages::setCustomMessages( $validator );
 
-        $this->status = (bool) preg_match("/^(\d{5}-?\d{5})$/", $value);
+        $this->status = (bool) preg_match("/^([13456789]{5}-?\d{5})$/", $value);
 
         return $this->status;
     }


### PR DESCRIPTION
Hi,
The first 5 digits of Iranian postal codes don't include the numbers 0 and 2. This change makes the rule more accurate.
@mohamadx